### PR TITLE
:bug: Fix resource leaks causing CLOSE_WAIT connections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,10 @@
                     <groupId>junit</groupId>
                     <artifactId>junit</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>com.springsource.org.apache.commons.io</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -199,6 +203,11 @@
         </dependency>
 
         <!--Util-->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.15.1</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/src/main/java/org/reactome/server/service/controller/citation/CitationController.java
+++ b/src/main/java/org/reactome/server/service/controller/citation/CitationController.java
@@ -170,12 +170,11 @@ public class CitationController {
             response.setContentType(contentType);
             response.setHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
 
-            InputStream in = new ByteArrayInputStream(citationString.getBytes(StandardCharsets.UTF_8));
-            OutputStream out = response.getOutputStream();
-            IOUtils.copy(in, out);
-            out.flush();
-            out.close();
-            in.close();
+            try (InputStream in = new ByteArrayInputStream(citationString.getBytes(StandardCharsets.UTF_8))) {
+                OutputStream out = response.getOutputStream();
+                IOUtils.copy(in, out);
+                out.flush();
+            }
         }
     }
 

--- a/src/main/java/org/reactome/server/service/controller/exporter/PptxExporterController.java
+++ b/src/main/java/org/reactome/server/service/controller/exporter/PptxExporterController.java
@@ -102,12 +102,11 @@ public class PptxExporterController {
         // when returning a FileSystemResource using Spring, then the file won't be deleted because it still has the
         // reference to the file and then we cannot delete. Writing the file directly in the response allows us to
         // delete only the temporary file.
-        OutputStream out = response.getOutputStream();
-        FileInputStream in = new FileInputStream(pptx);
-        IOUtils.copy(in, out);
-        out.flush();
-        out.close();
-        in.close();
+        try (FileInputStream in = new FileInputStream(pptx)) {
+            OutputStream out = response.getOutputStream();
+            IOUtils.copy(in, out);
+            out.flush();
+        }
 
         // deleting the file in case it is decorated.
         if (decorator.isDecorated() && !pptx.delete()) {
@@ -160,12 +159,11 @@ public class PptxExporterController {
         // when returning a FileSystemResource using Spring, then the file won't be deleted because it still has the
         // reference to the file and then we cannot delete. Writing the file directly in the response allows us to
         // delete only the temporary file.
-        OutputStream out = response.getOutputStream();
-        FileInputStream in = new FileInputStream(pptx);
-        IOUtils.copy(in, out);
-        out.flush();
-        out.close();
-        in.close();
+        try (FileInputStream in = new FileInputStream(pptx)) {
+            OutputStream out = response.getOutputStream();
+            IOUtils.copy(in, out);
+            out.flush();
+        }
 
         // deleting the file in case it is decorated.
         if (decorator.isDecorated() && !pptx.delete()) {

--- a/src/main/java/org/reactome/server/service/controller/exporter/SbxxExporterController.java
+++ b/src/main/java/org/reactome/server/service/controller/exporter/SbxxExporterController.java
@@ -65,10 +65,11 @@ public class SbxxExporterController {
         String fileName = event.getStId() + SBGN_FILE_EXTENSION;
         response.setContentType("application/sbgn+xml");
         response.setHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
-        OutputStream out = response.getOutputStream();
-        IOUtils.copy(getSBGN(event, fileName), out);
-        out.flush();
-        out.close();
+        try (InputStream sbgn = getSBGN(event, fileName)) {
+            OutputStream out = response.getOutputStream();
+            IOUtils.copy(sbgn, out);
+            out.flush();
+        }
     }
 
     private InputStream getSBGN(Event event, String fileName) throws FileNotFoundException {
@@ -106,10 +107,11 @@ public class SbxxExporterController {
         String fileName = event.getStId() + SBML_FILE_EXTENSION;
         response.setContentType("application/sbml+xml");
         response.setHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
-        OutputStream out = response.getOutputStream();
-        IOUtils.copy(getSBML(event, fileName), out);
-        out.flush();
-        out.close();
+        try (InputStream sbml = getSBML(event, fileName)) {
+            OutputStream out = response.getOutputStream();
+            IOUtils.copy(sbml, out);
+            out.flush();
+        }
     }
 
     private InputStream getSBML(Event event, String fileName) throws FileNotFoundException {


### PR DESCRIPTION
Fixed 5 instances of improper stream management that could cause CLOSE_WAIT connections in Apache when exceptions occur during file export operations.

Changes:
- PptxExporterController: Wrapped FileInputStream in try-with-resources for both diagramPPTX() and reactionPPTX() methods
- SbxxExporterController: Wrapped InputStream in try-with-resources for both eventSBGN() and eventSBML() methods
- CitationController: Wrapped InputStream in try-with-resources for exportCitation() method

Previously, if IOUtils.copy() or flush() threw an exception, streams would not be closed, leaving file descriptors and HTTP connections in CLOSE_WAIT state. The try-with-resources pattern ensures proper cleanup even when exceptions occur.

Note: HttpServletResponse.getOutputStream() is intentionally not closed as the servlet container manages its lifecycle.

🤖 Generated with Claude Code (https://claude.com/claude-code)

@jweiser and I created this and compiled it, but did not run it. We are trying to fix the open Apache2 connections. We know you are on vacation. If you are not able to take a look, could you at least let us know if what is on prod is from the latest commit on the Master branch? And would it be safe to make this change inside and test it first, making sure it still runs? 